### PR TITLE
Add Phase 1 Weekly Growth Planning Pack — Summer Builder 1.0

### DIFF
--- a/docs/growth-planning/phase1/content_hooks.md
+++ b/docs/growth-planning/phase1/content_hooks.md
@@ -1,0 +1,78 @@
+# Content Hooks — Summer Builder 1.0 Recruitment
+
+Source context:
+- OM Marketing OS Strategy
+- OM Marketing OS Airtable Schema
+- Builder 1.0 Asset Pack
+- Agent Prompt Library
+
+INTERNAL ONLY — Planning-level ideas. Requires proof before publishing.
+
+Campaign: Summer Builder 1.0 Recruitment
+Interest forms: May 1–29 | Program: June 24–August 28
+
+---
+
+## Hook 01
+
+**Category:** Founder recruitment
+**Hook:** "Most people with a good idea don't need more time to think. They need 9 weeks and a structure that forces a test."
+**What this needs to become a post:** A specific example of what the 9-week structure looks like. What happens in week 1? What does a builder actually do?
+**Missing proof:** Description of the Builder 1.0 curriculum or weekly cadence — [Unknown if documented]
+**Format suggestion:** Short-form text post. No image required. Link to interest form in first comment or bio.
+**CTA:** Interest forms close May 29.
+
+---
+
+## Hook 02
+
+**Category:** Mentor recruitment
+**Hook:** "We don't need more general advice in this space. We need people who've done the specific thing and are willing to say what actually happened."
+**What this needs to become a post:** A description of what OM mentors actually do. How much time. What the interaction looks like. What kind of feedback is useful.
+**Missing proof:** Mentor role description — [Unknown if defined]. Quote or story from a past mentor — [Unknown]
+**Format suggestion:** Text post or short interview format if a mentor is willing to go on record.
+**CTA:** If you've built something and want to be useful this summer, reach out.
+
+---
+
+## Hook 03
+
+**Category:** Ecosystem proof
+**Hook:** "Builder programs work when the people in the room are self-selected. Here's what we actually look for."
+**What this needs to become a post:** The specific criteria OM uses to evaluate interest forms. What makes someone a strong Builder 1.0 candidate.
+**Missing proof:** Selection criteria documentation — [Unknown if internal only or shareable]. Past cohort stats if any — [Unknown]
+**Format suggestion:** List post. Can be published without quotes or data if criteria are clearly stated.
+**CTA:** Interest forms open May 1.
+
+---
+
+## Hook 04
+
+**Category:** Event promotion
+**Hook:** "Interest forms for Summer Builder 1.0 close May 29. If you've been thinking about it, this is the window."
+**What this needs to become a post:** Accurate program dates and CTA. No embellishment needed — the deadline is the hook.
+**Missing proof:** Nothing missing — this can be written and scheduled now.
+**Format suggestion:** Short post, 3-5 lines. Post once per week from May 1–May 22. Final push post on May 27–28.
+**CTA:** Link to interest form.
+
+---
+
+## Hook 05
+
+**Category:** Staff expertise
+**Hook:** "Here's how we decide who gets into Builder: the criteria we actually use, not a filtered version."
+**What this needs to become a post:** Honest description of the selection process. What OM looks for. What disqualifies someone. What the follow-up looks like after form submission.
+**Missing proof:** Internal selection rubric or criteria — [Unknown if documented]. Whoever owns intake needs to sign off on what can be shared publicly.
+**Format suggestion:** Medium-length post from a named OM staff member. Not a press release. First-person, direct.
+**CTA:** If you're on the fence, complete the form — we'll tell you where you stand.
+
+---
+
+## Notes for Operator
+
+- Hook 04 is the only one ready to write and post today — no proof required
+- Hooks 01, 03, 05 require internal documentation to be confirmed before publishing
+- Hook 02 requires a defined mentor role description before outreach or posting
+- Hook 05 requires a named author from OM staff — do not publish anonymously
+- All posts should include the interest form link and the May 29 deadline
+- Do not post claims about outcomes, alumni success, or cohort quality without documented proof

--- a/docs/growth-planning/phase1/growth_targets.md
+++ b/docs/growth-planning/phase1/growth_targets.md
@@ -1,0 +1,120 @@
+# Growth Targets — Week of [DATE]
+
+Source context:
+- OM Marketing OS Strategy
+- OM Marketing OS Airtable Schema
+- Builder 1.0 Asset Pack
+- Agent Prompt Library
+
+Campaign: Summer Builder 1.0 Recruitment
+Interest forms: May 1–29 | Program: June 24–August 28
+CTA: Complete the interest form
+
+---
+
+## Target 01
+
+**Name/Org:** [Name of specific individual — experienced operator, currently consulting or between roles]
+**Type:** Founder candidate
+**Why they matter:** Has domain depth and operational history. Priority profile for Builder 1.0. Likely has a problem worth testing.
+**Campaign:** Summer Builder 1.0 Recruitment
+**Next step:** Direct outreach — personal note from OM staff. Lead with the deadline (May 29) and the fact that forms are open now.
+
+---
+
+## Target 02
+
+**Name/Org:** [Name — recent corporate exit, mid-career, industry: [Unknown]]
+**Type:** Founder candidate
+**Why they matter:** Corporate exits with domain knowledge are exactly the experienced operator profile. Often have a specific insight or recurring problem they've already identified.
+**Campaign:** Summer Builder 1.0 Recruitment
+**Next step:** Warm intro through mutual if possible. If not, LinkedIn outreach referencing their background — not generic.
+
+---
+
+## Target 03
+
+**Name/Org:** [Name — accelerator alum who did not raise or scale, still active in ecosystem]
+**Type:** Founder candidate
+**Why they matter:** Has already gone through a validation process. Understands what it takes. May have a second idea or a pivot worth testing.
+**Campaign:** Summer Builder 1.0 Recruitment
+**Next step:** Reference their prior program experience in outreach. Ask if they're working on anything new.
+
+---
+
+## Target 04
+
+**Name/Org:** [Name — professional with a side project or recurring idea, 7–15 years industry experience]
+**Type:** Founder candidate
+**Why they matter:** Has the operator profile without having taken the leap. Builder 1.0 is designed for exactly this window.
+**Campaign:** Summer Builder 1.0 Recruitment
+**Next step:** Peer referral is strongest path here. Ask existing network to identify this type directly.
+
+---
+
+## Target 05
+
+**Name/Org:** [Name — active ecosystem mentor, has mentored at [Unknown] program in past 12 months]
+**Type:** Mentor
+**Why they matter:** Builder 1.0 needs practitioners who can give direct feedback during the June–August window. This profile has recent mentorship reps.
+**Campaign:** Summer Builder 1.0 Recruitment (mentor pipeline)
+**Next step:** Separate ask from builder ask. Reach out specifically about mentor role — not as a builder candidate.
+
+---
+
+## Target 06
+
+**Name/Org:** [Name — founder who completed a prior OM program or touchpoint]
+**Type:** Founder candidate / Referral source
+**Why they matter:** Has firsthand knowledge of OM quality. Can apply themselves or refer qualified candidates. Highest-trust referral source available.
+**Campaign:** Summer Builder 1.0 Recruitment
+**Next step:** Direct outreach. Ask if they're working on anything new OR if they know 1–2 people who should apply.
+
+---
+
+## Target 07
+
+**Name/Org:** [Local SBDC office — branch: [Unverified]]
+**Type:** Partner / Referral source
+**Why they matter:** SBDC counselors work with early-stage people weekly. They can identify and refer qualified Builder 1.0 candidates who already have the operator profile.
+**Campaign:** Summer Builder 1.0 Recruitment
+**Next step:** One-page program brief + direct ask to share with their current client list. Request intro call with program director.
+
+---
+
+## Target 08
+
+**Name/Org:** [UL Lafayette entrepreneurship center or similar university program — contact: [Unverified]]
+**Type:** Partner / Referral source
+**Why they matter:** Connects OM to alumni and grad students with technical skills or industry insight who haven't yet tested an idea formally.
+**Campaign:** Summer Builder 1.0 Recruitment
+**Next step:** Email to program director with program brief. Ask to feature in their next newsletter or event.
+
+---
+
+## Target 09
+
+**Name/Org:** [Professional association chapter — org: [Unknown], e.g., ALPFA, NSBE, local or Louisiana chapter]
+**Type:** Partner / Audience
+**Why they matter:** Membership skews toward experienced professionals. High overlap with the experienced operator profile. Chapter communications reach warm audiences.
+**Campaign:** Summer Builder 1.0 Recruitment
+**Next step:** Identify chapter president or events lead. Ask for 1 email blast or event mention before May 15.
+
+---
+
+## Target 10
+
+**Name/Org:** [Corporate innovation or DEI lead at mid-to-large employer in target geography]
+**Type:** Corporate / Sponsor candidate
+**Why they matter:** Can refer employees considering a career pivot. May also have interest in sponsoring the cohort or engaging with Builder graduates.
+**Campaign:** Summer Builder 1.0 Recruitment + sponsor pipeline
+**Next step:** Intro meeting to discuss referral partnership. Do not lead with sponsorship — lead with the candidate referral angle.
+
+---
+
+## Notes for Operator
+
+- Targets 01–06 = direct outreach for applications
+- Targets 07–10 = referral/partner channel activation
+- Fill in [Unknown] and [Unverified] fields before sending outreach
+- All outreach should be sent before May 15 to allow time for form completion before May 29 close

--- a/docs/growth-planning/phase1/outreach_angles.md
+++ b/docs/growth-planning/phase1/outreach_angles.md
@@ -1,0 +1,79 @@
+# Outreach Angles — Summer Builder 1.0 Recruitment
+
+Source context:
+- OM Marketing OS Strategy
+- OM Marketing OS Airtable Schema
+- Builder 1.0 Asset Pack
+- Agent Prompt Library
+
+INTERNAL ONLY — These are planning-level drafts. Not for public distribution.
+
+Campaign: Summer Builder 1.0 Recruitment
+Interest forms: May 1–29 | Program: June 24–August 28
+CTA: Complete the interest form
+
+---
+
+## Angle 01 — Experienced Operator with an Unbuilt Idea
+
+**Audience:** Professionals with 8–20 years of industry experience who have identified a recurring problem or gap but haven't acted on it
+**What we say:** You've seen the same problem enough times to know how to fix it. Builder gives you a structured 9 weeks to test whether it's worth building.
+**Value to them:** A low-risk, structured environment to test an idea without leaving their current situation immediately. Cohort accountability. OM staff support.
+**Value to OM:** Core recruitment target. This profile produces the highest-quality builders and the most credible proof stories.
+**Ask:** Complete the interest form before May 29. Takes [Unknown] minutes. No commitment to apply — just an expression of interest.
+**Label:** INTERNAL ONLY
+
+---
+
+## Angle 02 — Recent or Planned Career Transition
+
+**Audience:** People who have recently left a role, are planning to, or are between things and considering what to do next
+**What we say:** If you're between things and have been sitting on an idea, Builder 1.0 starts June 24. The interest form closes May 29.
+**Value to them:** Momentum and structure during a period that can otherwise stall. Peer cohort. Concrete deliverables to show for the summer.
+**Value to OM:** Captures a high-intent window. People in transition are ready to act — they just need a clear next step.
+**Ask:** Complete the interest form. We'll follow up after review.
+**Label:** INTERNAL ONLY
+
+---
+
+## Angle 03 — Referral Ask to Network Contacts and Partners
+
+**Audience:** OM alumni, partners, ecosystem connectors, professional association leads
+**What we say:** We're recruiting for Builder 1.0 and the priority profile is experienced operators — people with industry depth who have an idea or a recurring problem they've been thinking about. Who in your network fits that?
+**Value to them:** They get to make a meaningful introduction. Positions them as someone connected to a real opportunity.
+**Value to OM:** Warm referrals convert at higher rates than cold outreach. Referral source data also supports LA.IO / LEDA reporting.
+**Ask:** Name 1–2 people they know who fit the profile. Offer to send a one-pager they can forward directly.
+**Label:** INTERNAL ONLY
+
+---
+
+## Angle 04 — Mentor Recruitment (Separate from Builder Ask)
+
+**Audience:** Practitioners with hands-on experience building, operating, or scaling something — not general business advisors
+**What we say:** Builder 1.0 runs June 24–August 28. We're looking for mentors who can give direct, specific feedback to early-stage builders. If you've done the thing, your time is useful here.
+**Value to them:** Direct access to motivated early-stage builders. OM relationship. Credit in OM reporting and materials.
+**Value to OM:** Mentor quality determines cohort quality. Practitioners > generalists.
+**Ask:** 1–2 hours per week during the program window. Specific ask is [Unknown — define before outreach].
+**Label:** INTERNAL ONLY
+
+---
+
+## Angle 05 — Corporate Referral / Awareness Angle
+
+**Audience:** Corporate innovation leads, DEI program managers, HR business partners at mid-to-large employers in target geography
+**What we say:** We're running a structured builder program this summer for experienced professionals testing business ideas. If you have employees who are thinking about what's next, Builder 1.0 is a real option — not a seminar.
+**Value to them:** A credible, external resource they can refer employees to. Positions them as supportive of entrepreneurial ambition without having to build something internally.
+**Value to OM:** Corporate referrals produce high-quality candidates. Also opens a longer-term sponsorship conversation after trust is established.
+**Ask:** Share the interest form with employees who might be interested. No formal partnership required — just a forward.
+**Label:** INTERNAL ONLY
+
+---
+
+## Notes for Operator
+
+- Angles 01–02 = direct candidate outreach
+- Angle 03 = referral activation (use with targets 06–10 in growth_targets.md)
+- Angle 04 = mentor pipeline (separate track — do not conflate with builder recruitment)
+- Angle 05 = corporate channel (long lead time — start now even if results come after May 29)
+- All outreach should reference the May 29 deadline and the June 24 program start
+- Do not imply that completing the interest form is a commitment to participate

--- a/docs/growth-planning/phase1/partnership_targets.md
+++ b/docs/growth-planning/phase1/partnership_targets.md
@@ -1,0 +1,69 @@
+# Partnership Targets — Summer Builder 1.0 Recruitment
+
+Source context:
+- OM Marketing OS Strategy
+- OM Marketing OS Airtable Schema
+- Builder 1.0 Asset Pack
+- Agent Prompt Library
+
+Campaign: Summer Builder 1.0 Recruitment
+Interest forms: May 1–29 | Program: June 24–August 28
+
+---
+
+## Partner 01
+
+**Org:** [Local SBDC office — branch: [Unverified]]
+**Ecosystem role:** Free business advising for early-stage entrepreneurs. Works with people actively considering starting or testing a business.
+**Ideal contact role:** Program director or lead counselor
+**Why OM should engage:** SBDC counselors are already meeting weekly with the exact profile Builder 1.0 is recruiting — people with an idea or recurring problem who haven't yet formalized a test. This is a warm referral channel, not a cold one.
+**What we should ask for:** One email to their current client list with the Builder 1.0 interest form link. If they can't do a direct email, ask to be listed on their resource page or mentioned at their next intake session.
+
+---
+
+## Partner 02
+
+**Org:** [UL Lafayette entrepreneurship or innovation program — contact: [Unverified]]
+**Ecosystem role:** Connects students, alumni, and faculty to startup resources. Often has an active newsletter and event calendar.
+**Ideal contact role:** Director of entrepreneurship programs or alumni engagement lead
+**Why OM should engage:** Alumni networks include people 5–15 years into careers who have domain expertise and may be at a point where they're considering something new. Undergrad and grad programs also surface technically skilled candidates.
+**What we should ask for:** Feature in their next newsletter before May 15. If they have an event in May, ask for a 2-minute mention or a table at the event. Provide them a one-pager they can forward without editing.
+
+---
+
+## Partner 03
+
+**Org:** [LEDA, LA.IO, or aligned workforce development organization — contact: [Unverified]]
+**Ecosystem role:** Supports founders, working adults through transitions, or regional startup ecosystem programming. Often has direct contact with experienced operators and referral partners.
+**Ideal contact role:** Program director, ecosystem lead, or case manager supervisor
+**Why OM should engage:** These organizations already work with people who are between jobs, testing new ideas, or carrying domain insight worth validating. The relationship also supports LA.IO and LEDA reporting goals.
+**What we should ask for:** Referral agreement or informal referral process. Ask them to flag Builder 1.0 to people who meet the operator profile. Share criteria clearly so they can self-screen referrals.
+
+---
+
+## Partner 04
+
+**Org:** [Professional association — org: [Unknown], e.g., ALPFA, NSBE, local or Louisiana chapter]
+**Ecosystem role:** Membership organization for professionals in a specific demographic or industry. Hosts events, distributes newsletters, maintains active member communication channels.
+**Ideal contact role:** Chapter president, events chair, or communications lead
+**Why OM should engage:** Membership skews toward experienced professionals — exactly the priority audience for Builder 1.0. Chapter communications have higher open rates than cold outreach. OM gains access to a warm, pre-qualified audience in one touchpoint.
+**What we should ask for:** One mention in their next member email or newsletter. If they have a May event, request a 2-minute intro or table presence. Do not ask for a formal partnership until there's a relationship established.
+
+---
+
+## Partner 05
+
+**Org:** [Community foundation, CDFI, One Acadiana, or aligned regional partner — contact: [Unverified]]
+**Ecosystem role:** Funds community development initiatives or connects entrepreneurs to regional business resources. Often has relationships with founders, small business owners, and workforce development partners.
+**Ideal contact role:** Program officer, entrepreneurship portfolio lead, or ecosystem partnerships lead
+**Why OM should engage:** Relationship supports LA.IO and LEDA reporting requirements. These organizations can refer candidates, co-promote programming, and provide legitimacy signals to the communities OM is trying to reach. Long-term, this is also a sponsorship or grant pathway.
+**What we should ask for:** Intro meeting. Present Builder 1.0 and the OM model. Ask if there are candidates in their network who should apply. Do not lead with funding ask.
+
+---
+
+## Notes for Operator
+
+- All 5 are referral-first relationships — the ask is always candidate referrals before anything else
+- Do not pitch sponsorship in a first contact with any of these partners
+- Provide a simple one-pager for each partner to forward — do not make them synthesize your pitch
+- Track which partners actually refer applicants — this data matters for LA.IO / LEDA reporting

--- a/docs/growth-planning/phase1/weekly_growth_plan.md
+++ b/docs/growth-planning/phase1/weekly_growth_plan.md
@@ -1,0 +1,113 @@
+# Weekly Growth Plan — Summer Builder 1.0 Recruitment
+
+Source context:
+- OM Marketing OS Strategy
+- OM Marketing OS Airtable Schema
+- Builder 1.0 Asset Pack
+- Agent Prompt Library
+
+Week of: [DATE — fill before use]
+Plan owner: [OM staff name]
+Campaign: Summer Builder 1.0 Recruitment
+Interest forms: May 1–29 | Program: June 24–August 28
+CTA: Complete the interest form
+
+---
+
+## 1. Who We Contact
+
+### Direct Outreach (applications)
+
+| Priority | Target | Type | Angle |
+|----------|--------|------|-------|
+| 1 | [Experienced operator — name: [Unknown]] | Founder candidate | Angle 01 — Operator with unbuilt idea |
+| 2 | [Recent career transition — name: [Unknown]] | Founder candidate | Angle 02 — Career transition window |
+| 3 | [Prior OM program alum — name: [Unknown]] | Founder candidate / Referral | Angle 03 — Referral ask |
+| 4 | [Active ecosystem mentor — name: [Unknown]] | Mentor | Angle 04 — Mentor recruitment |
+
+### Referral Channel Activation
+
+| Priority | Target | Type | Angle |
+|----------|--------|------|-------|
+| 1 | [Local SBDC office — branch: [Unverified]] | Partner | Angle 03 — Referral ask |
+| 2 | [Professional association — org: [Unknown], local or Louisiana chapter] | Partner | Angle 03 — Referral ask |
+
+**This week's minimum:** Contact 2 direct candidates + 1 referral partner before [DATE + 3 days].
+
+---
+
+## 2. Why They Matter
+
+**Experienced operators** are the priority profile. They have domain depth, have identified real problems, and produce the most useful proof stories after the program. Every week that passes without contacting them is a week closer to the May 29 close with no pipeline.
+
+**Referral partners** (SBDC, associations) have existing relationships with this profile. One email from them reaches more qualified candidates than 20 cold outreach attempts from OM.
+
+**Prior OM alumni** are the highest-trust referral source available. They have firsthand knowledge of OM quality. Activating them this week costs 1 message and can return multiple applications.
+
+---
+
+## 3. What We Ask
+
+| Target type | Ask |
+|-------------|-----|
+| Founder candidate | Complete the interest form before May 29 — [link] |
+| Potential referral source (personal) | Name 1–2 people who fit the operator profile. We'll follow up. |
+| Partner org | Share the interest form with your audience before May 15. We'll provide a one-pager. |
+| Mentor candidate | Confirm interest in a mentor role for June 24–August 28. Details to follow. |
+
+**Do not ask for anything else in a first contact.** No sponsorship asks. No commitment asks. One action per outreach.
+
+---
+
+## 4. What Content We Create
+
+| Ready to create now | Requires proof first |
+|--------------------|----------------------|
+| Hook 04 — Deadline post ("forms close May 29") | Hook 01 — Needs curriculum description |
+| Basic program info post (dates, CTA, link) | Hook 03 — Needs selection criteria confirmed |
+| Referral ask post to OM network | Hook 05 — Needs named author + internal rubric |
+
+**This week's minimum:** Publish 1 post. Hook 04 is ready — no proof required. Schedule it for [DATE].
+
+**Do not publish Hook 01, 03, or 05 until missing proof items are resolved.**
+
+---
+
+## 5. What Proof We Need
+
+The following items are missing or unconfirmed. Without them, specific content cannot be published and some outreach angles are incomplete.
+
+| Proof item | Needed for | Status | Owner |
+|------------|-----------|--------|-------|
+| Builder 1.0 weekly structure / curriculum description | Hook 01, Angle 01 | [Unknown] | [Unknown] |
+| Selection criteria for interest form review | Hook 03, Hook 05 | [Unknown] | [Unknown] |
+| Mentor role description (time commitment, format) | Angle 04, Hook 02 | [Unknown] | [Unknown] |
+| Interest form link (confirmed live May 1) | All outreach | [Unknown] | [Unknown] |
+| Named OM staff author for Hook 05 | Hook 05 | [Unknown] | [Unknown] |
+| Prior cohort stats or outcomes (if any exist) | Hook 03 (optional) | [Unknown] | [Unknown] |
+
+**Minimum proof needed to execute this week:** Interest form link confirmed live. Everything else can be addressed in parallel.
+
+---
+
+## Operator Checklist — This Week
+
+- [ ] Confirm interest form is live and link is correct
+- [ ] Identify 2 specific people to contact today (use growth_targets.md)
+- [ ] Send outreach to both using relevant angle from outreach_angles.md
+- [ ] Identify 1 referral partner to contact (use partnership_targets.md)
+- [ ] Send referral partner outreach with one-pager attached
+- [ ] Publish Hook 04 post this week
+- [ ] Identify owner for each missing proof item above
+- [ ] Schedule next weekly plan review before [DATE + 7 days]
+
+---
+
+## What Success Looks Like This Week
+
+- 2 direct outreach messages sent to founder candidates
+- 1 referral partner contacted
+- 1 post published
+- 1 proof gap assigned to an owner
+
+If none of those happened, the plan did not execute — not a planning problem, an execution problem.

--- a/docs/growth-planning/phase1/weekly_growth_plan.md
+++ b/docs/growth-planning/phase1/weekly_growth_plan.md
@@ -64,12 +64,13 @@ CTA: Complete the interest form
 | Ready to create now | Requires proof first |
 |--------------------|----------------------|
 | Hook 04 — Deadline post ("forms close May 29") | Hook 01 — Needs curriculum description |
-| Basic program info post (dates, CTA, link) | Hook 03 — Needs selection criteria confirmed |
-| Referral ask post to OM network | Hook 05 — Needs named author + internal rubric |
+| Basic program info post (dates, CTA, link) | Hook 02 — Needs mentor role description |
+| Referral ask post to OM network | Hook 03 — Needs selection criteria confirmed |
+| | Hook 05 — Needs named author + internal rubric |
 
 **This week's minimum:** Publish 1 post. Hook 04 is ready — no proof required. Schedule it for [DATE].
 
-**Do not publish Hook 01, 03, or 05 until missing proof items are resolved.**
+**Do not publish Hook 01, 02, 03, or 05 until missing proof items are resolved.**
 
 ---
 


### PR DESCRIPTION
This ports the Phase 1 growth planning pack into the correct repo.

This change adds five internal planning documents under `docs/growth-planning/phase1/` for the Summer Builder 1.0 recruitment campaign. The pack is intended for operator use, not public distribution, and keeps the original planning constraints intact: unknown facts remain marked as `[Unknown]`, proof-gated content stays flagged as not ready for publishing, and the materials stay focused on same-day execution for outreach, partner activation, and content preparation.

The move matters because these materials belong with OM Marketing OS and the OM Content Engine planning layer rather than OM Venture OS. Keeping them here preserves the architecture boundary between founder-product runtime work and marketing, proof, partner, and reporting operations. This PR does not modify Venture OS runtime behavior, and it does not introduce UI, scraping, agents, automation, or Airtable sync changes.

This ready-for-review PR includes the Hook 02 proof-gating fix from the draft PR review: Hook 02 now appears in the `Requires proof first` table and in the warning against publishing without proof.

Validation from the draft PR was documentation-only: `python3 -m pytest -q` passed locally with `183 passed`.